### PR TITLE
FastQueue Domain Logic Error

### DIFF
--- a/lib/fast-queue.js
+++ b/lib/fast-queue.js
@@ -25,7 +25,7 @@ class FastQueue extends Promise {
 		const arr = this[array];
 		if (arr.length === this[length]) {
 			arr.length *= 2;
-			arrayMove(arr, arr.length, this[front]);
+			arrayMove(arr, this[length], this[front]);
 		}
 		arr[(this[front] + this[length]++) & (arr.length - 1)] = value;
 	}

--- a/test/fast-queue.js
+++ b/test/fast-queue.js
@@ -1,0 +1,18 @@
+'use strict';
+const { expect } = require('chai');
+const FastQueue = require('../lib/fast-queue');
+const shared = require('../lib/shared');
+
+describe('[shared.push]', function () {
+	it('should maintain cyclic buffer continuity', function () {
+		const fq = new FastQueue((resolve) => resolve())
+		fq[shared.push](0)
+		expect(fq[shared.shift]()).to.equal(0)
+		for (let i = 0; i < 17; i++) {
+			fq[shared.push](i)
+		}
+		for (let i = 0; !fq[shared.isEmpty](); i++) {
+			expect(fq[shared.shift]()).to.equal(i)
+		}
+	});
+});


### PR DESCRIPTION
While trying to understand the library, I may have caught an error in the preservation of some state invariants.
https://github.com/JoshuaWise/wise-river/blob/ed70d3b07a19116c6556ec748f7d2cbdae725180/lib/fast-queue.js#L19
asserts lengths that are powers of 2.
However, the code
https://github.com/JoshuaWise/wise-river/blob/ed70d3b07a19116c6556ec748f7d2cbdae725180/lib/fast-queue.js#L27-L28
https://github.com/JoshuaWise/wise-river/blob/ed70d3b07a19116c6556ec748f7d2cbdae725180/lib/fast-queue.js#L60-L65
1. appends elements to the end of the array, which may violate the assertion
2. inserts discontinuities between adjacent elements.

It looks to me like the intent is to unwrap the cycle.

If this is the issue I perceive it to be, you may want to reformulate my test. Since I don't yet understand the abstraction, my test only exposes a fault in a component underneath all those layers.